### PR TITLE
Use SiteSettings, not hard-coded "members" group name

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -6,7 +6,12 @@
   const groups = user.groups || [];
   var isMember = false;
   
-  if (groups.filter(function(g) { return g.name === 'members'; }).length > 0) {
+  // Use Discourse.SiteSettings instead of hard coded group name "members"
+  const groupsWithAccessToMemberDirectory = [
+    Discourse.SiteSettings.libra_discourse_member_directory_group_name,
+    ...(Discourse.SiteSettings.libra_discourse_member_directory_groups_with_member_directory_access || '').split('|')
+  ].filter(function(groupName) { return groupName.length > 0; });
+  if (groups.filter(function(g) { return groupsWithAccessToMemberDirectory.includes(g.name); }).length > 0) {
     isMember = true;
   }
 


### PR DESCRIPTION
@averyhadzi,

Lauren requested additional functionalities allowing for other groups, not just the "members" group to be able to have access to (but not listed in) the members directory.
This change will use the names of groups listed in the site settings, not the hard-coded value previously used.

Make sure to pull latest before making any additional changes to this plugin to keep the git tree consistent and to avoid merge conflicts.